### PR TITLE
Fix duplicate option in README

### DIFF
--- a/Code/notebook/Analisi della polarizzazione dei contenuti/README.md
+++ b/Code/notebook/Analisi della polarizzazione dei contenuti/README.md
@@ -277,4 +277,4 @@ Alla fine dell’esecuzione, nella directory `--output-dir` troverai:
 - python.exe main.py --use-tfidf --use-lsa --output-dir "Code/notebook/Analisi della polarizzazione dei contenuti/output/2"
 - python.exe main.py --use-tfidf --method kmeans --n-clusters 15 --output-dir "Code/notebook/Analisi della polarizzazione dei contenuti/output/3"
 - python.exe main.py --no-tfidf --output-dir "Code/notebook/Analisi della polarizzazione dei contenuti/output/4"
-- python.exe main.py --no-tfidf --use-umap --embedding-model all-mpnet-base-v2 --use-umap --output-dir "Code/notebook/Analisi della polarizzazione dei contenuti/output/5"
+- python.exe main.py --no-tfidf --use-umap --embedding-model all-mpnet-base-v2 --output-dir "Code/notebook/Analisi della polarizzazione dei contenuti/output/5"


### PR DESCRIPTION
## Summary
- remove duplicate `--use-umap` from example command in polarization analysis README

## Testing
- `git show -n 1`

------
https://chatgpt.com/codex/tasks/task_e_6849767de9ec8323b35a202ea7616dbd