### PR TITLE
Fix path handling with os.path.join

### DIFF
--- a/Code/notebook/Analisi della polarizzazione dei contenuti/main.py
+++ b/Code/notebook/Analisi della polarizzazione dei contenuti/main.py
@@ -28,7 +28,9 @@ def parse_args():
     parser.add_argument(
         "--output-dir",
         type=str,
-        default=r"Code/notebook/Analisi della polarizzazione dei contenuti/output",
+        default=os.path.join(
+            os.path.dirname(__file__), "output"
+        ),
         help="Cartella in cui salvare tutti i risultati.",
     )
 

--- a/Code/notebook/Studio della propagazione dell'influenza/main.py
+++ b/Code/notebook/Studio della propagazione dell'influenza/main.py
@@ -89,7 +89,9 @@ if __name__ == "__main__":
         logger.info("Optimization completed successfully.")
         run_models_on_differnt_optimizer(optimization_results, gc, save_fig, steps)
         if save_to_file:
-            output_dir = r"Code\notebook\Studio della propagazione dell'influenza\output/optimizer_output"
+            output_dir = os.path.join(
+                os.path.dirname(__file__), "output", "optimizer_output"
+            )
             logger.info("Saving optimization results to directory: %s", output_dir)
             save_results_to_file(optimization_results, os.path.join(output_dir, "save"))
             logger.info("Results saved successfully.")

--- a/Code/notebook/Studio della propagazione dell'influenza/utils/run_models.py
+++ b/Code/notebook/Studio della propagazione dell'influenza/utils/run_models.py
@@ -33,7 +33,9 @@ def run_models_on_different_seed_lengths(
     """
     graph = graph_builder.graph
     all_results = {}
-    output_dir = r"Code\notebook\Studio della propagazione dell'influenza\output/"+output
+    output_dir = os.path.join(
+        os.path.dirname(__file__), "..", "output", output
+    )
     for seed_length in seed_lengths:
         seed_nodes = [node for node, _ in top_influencers[:seed_length]]
     # Esecuzione dei modelli
@@ -52,10 +54,16 @@ def run_models_on_different_seed_lengths(
         )
         all_results[seed_length] = model_results
         if save_to_file:
-            save_results_to_file(model_results, os.path.join(output_dir+"/save", f"steps_{seed_length}"))
+            save_results_to_file(
+                model_results, os.path.join(output_dir, "save", f"steps_{seed_length}")
+            )
     if save_fig:
         plotter = Plotter()
-        plotter.plot_all_results(all_results, seed_lengths,output_dir+"/plot_comparative_seed_length")
+        plotter.plot_all_results(
+            all_results,
+            seed_lengths,
+            os.path.join(output_dir, "plot_comparative_seed_length"),
+        )
 
 
 def run_models_on_differnt_centralities(
@@ -90,7 +98,9 @@ def run_models_on_differnt_centralities(
                           "PageRank", "Katz Centrality","Eigenvector Centrality","HITS Hub Scores","HITS Authority Scores"]
     graph = graph_builder.graph
     seed_nodes_by_centrality = {}
-    output_dir = r"Code\notebook\Studio della propagazione dell'influenza\output/"+output
+    output_dir = os.path.join(
+        os.path.dirname(__file__), "..", "output", output
+    )
     for metric in centrality_metrics:
         sorted_nodes = sorted(centralities[metric].items(), key=lambda x: x[1], reverse=True)
         seed_nodes_by_centrality[metric] = [node for node, _ in sorted_nodes[:seed_length]]
@@ -113,11 +123,18 @@ def run_models_on_differnt_centralities(
             all_results_by_centrality[metric] = model_results
 
         if save_to_file:
-            save_results_to_file(model_results, os.path.join(output_dir + "/save", f"{metric}_steps_{seed_length}"))
+            save_results_to_file(
+                model_results, os.path.join(output_dir, "save", f"{metric}_steps_{seed_length}")
+            )
 
     if save_fig:
         plotter = Plotter()
-        plotter.plot_all_results(all_results_by_centrality, centrality_metrics,output_dir + "/plot_centrality_comparison",use_centrality_labels=True)
+        plotter.plot_all_results(
+            all_results_by_centrality,
+            centrality_metrics,
+            os.path.join(output_dir, "plot_centrality_comparison"),
+            use_centrality_labels=True,
+        )
 
 def run_models_on_differnt_optimizer(
     optimization_results,
@@ -144,7 +161,9 @@ def run_models_on_differnt_optimizer(
     graph = graph_builder.graph
  
     all_res = {}
-    output_dir = r"Code\notebook\Studio della propagazione dell'influenza\output/optimizer_output"
+    output_dir = os.path.join(
+        os.path.dirname(__file__), "..", "output", "optimizer_output"
+    )
     for method in optmizer_methods:
         seed_nodes = list(optimization_results[method])
         all_results_by_centrality = {}
@@ -173,4 +192,8 @@ def run_models_on_differnt_optimizer(
 
     if save_fig:
         plotter = Plotter()
-        plotter.plot_all_optimizer(dizionario_invertito, output_dir + "/plot_optimizer_comparison",save = True)
+        plotter.plot_all_optimizer(
+            dizionario_invertito,
+            os.path.join(output_dir, "plot_optimizer_comparison"),
+            save=True,
+        )

--- a/Code/notebook/graph/GraphConstructor.py
+++ b/Code/notebook/graph/GraphConstructor.py
@@ -68,12 +68,10 @@ def hits_scores(graph):
 class GraphConstructor:
     def __init__(
         self,
-        followers_paths=[
-            r"Code\data_extraction\data\processed\followers.csv",
-        ],
-        post_data_dir=r"Code/data_extraction/data/processed/post_data",
-        info_filepath=r"Code/notebook/graph/info/graph_info.json",
-        centralities_filepath=r"Code/notebook/graph/info/centralities_info.json",
+        followers_paths=None,
+        post_data_dir=None,
+        info_filepath=None,
+        centralities_filepath=None,
     ):
         """Inizializza la struttura e carica i dati di input.
 
@@ -88,6 +86,18 @@ class GraphConstructor:
         centralities_filepath : str, optional
             Percorso del file JSON per le centralità.
         """
+
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+        if followers_paths is None:
+            followers_paths = [
+                os.path.join(project_root, "Code", "data_extraction", "data", "processed", "followers.csv")
+            ]
+        if post_data_dir is None:
+            post_data_dir = os.path.join(project_root, "Code", "data_extraction", "data", "processed", "post_data")
+        if info_filepath is None:
+            info_filepath = os.path.join(os.path.dirname(__file__), "info", "graph_info.json")
+        if centralities_filepath is None:
+            centralities_filepath = os.path.join(os.path.dirname(__file__), "info", "centralities_info.json")
 
         self.df = pd.concat(
             [


### PR DESCRIPTION
## Summary
- replace hard-coded path strings with `os.path.join`
- compute default paths in `GraphConstructor`
- update notebook scripts to use joined paths

## Testing
- `python -m py_compile Code/notebook/graph/GraphConstructor.py`
- `python -m py_compile "Code/notebook/Studio della propagazione dell'influenza/utils/run_models.py"`
- `python -m py_compile "Code/notebook/Studio della propagazione dell'influenza/main.py"`
- `python -m py_compile "Code/notebook/Analisi della polarizzazione dei contenuti/main.py"`


------
https://chatgpt.com/codex/tasks/task_e_684dd34e733483238b200a3b1ee68dc6